### PR TITLE
fix(Chat): render response by using response text instead of adaptiveCards

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,5 +45,6 @@ module.exports = {
         'no-restricted-syntax': 'off',
         'no-undef': 'off',
         'import/prefer-default-export': 'off',
+        'comma-dangle': 'off',
     },
 };

--- a/components/Chat.vue
+++ b/components/Chat.vue
@@ -291,15 +291,10 @@ const sendMessage = async (input, parentMessageId = null) => {
                 title: result.title,
             };
         }
-        const adaptiveText = result.details.adaptiveCards?.[0]?.body?.[0]?.text?.trim();
-        if (adaptiveText) {
-            const base64regex = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
-            if (base64regex.test(adaptiveText) && activePresetToUse.value?.options?.useBase64 === true) {
-                messages.value[botMessageIndex].text = Buffer.from(adaptiveText, 'base64').toString();
-                messages.value[botMessageIndex].text += '\n🔓';
-            } else {
-                messages.value[botMessageIndex].text = adaptiveText;
-            }
+        const base64regex = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
+        if (base64regex.test(result.response) && activePresetToUse.value?.options?.useBase64 === true) {
+            messages.value[botMessageIndex].text = Buffer.from(result.response, 'base64').toString();
+            messages.value[botMessageIndex].text += '\n🔓';
         } else {
             messages.value[botMessageIndex].text = result.response;
         }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,49 +1,56 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
+    build: {
+        extend(config, ctx) {
+            if (ctx.isDev && ctx.isClient) {
+                config.devtool = 'eval-source-map';
+            }
+        }
+    },
     ssr: false,
     runtimeConfig: {
         public: {
             apiBaseUrl: process.env.NUXT_PUBLIC_API_BASE_URL,
-            password: process.env.PASSWORD,
-        },
+            password: process.env.PASSWORD
+        }
     },
     imports: {
-        dirs: ['stores'],
+        dirs: ['stores']
     },
     modules: [
         '@nuxtjs/tailwindcss',
         '@kevinmarrec/nuxt-pwa',
         'nuxt-icon',
         '@pinia/nuxt',
-        '@vueuse/nuxt',
+        '@vueuse/nuxt'
     ],
     css: [
         {
             src: '~/node_modules/highlight.js/styles/base16/dracula.css',
-            lang: 'css',
-        },
+            lang: 'css'
+        }
     ],
     pinia: {
-        autoImports: ['defineStore', 'acceptHMRUpdate'],
+        autoImports: ['defineStore', 'acceptHMRUpdate']
     },
     pwa: {
         icon: {
             source: './public/icon.png',
-            maskablePadding: 0,
+            maskablePadding: 0
         },
         meta: {
             name: 'PandoraAI',
             description: 'Multiple AI Web Chat Client',
             theme_color: '#7733ff',
             mobileAppIOS: true,
-            nativeUI: true,
+            nativeUI: true
         },
         manifest: {
             name: 'PandoraAI',
             description: 'Multiple AI Web Chat Client',
             background_color: '#7733ff',
             lang: 'en',
-            useWebmanifestExtension: false,
-        },
-    },
+            useWebmanifestExtension: false
+        }
+    }
 });


### PR DESCRIPTION
This PR will resolve #2.
For some reason the first adaptive card isn't guaranteed to contain all the response text.
From now on, the response text is used directly.